### PR TITLE
Fixed not being able to use tpa after being damaged.

### DIFF
--- a/BP/scripts/events/list/CombatValidation.js
+++ b/BP/scripts/events/list/CombatValidation.js
@@ -24,3 +24,25 @@ world.afterEvents.entityHurt.subscribe((event) => {
   
   db.store("bedrocktpa:hurted", hurtedData)
 })
+
+system.runInterval(() => {
+  let hurtedData = db.fetch("bedrocktpa:hurted", true);
+  if (!hurtedData.length) return;
+
+  const now = system.currentTick;
+  const updatedData = [];
+
+  for (const data of hurtedData) {
+    const player = world.getPlayers({ name: data.name })[0];
+
+    if (!player) continue;
+
+    if (now >= data.time) {
+      player.removeTag("bedrocktpa:hurted");
+    } else {
+      updatedData.push(data);
+    }
+  }
+
+  db.store("bedrocktpa:hurted", updatedData);
+}, 20);


### PR DESCRIPTION
Added a logic to remove "bedrocktpa:hurted" tag which allow players to use /tpa /back again.